### PR TITLE
Fix: [DEP0016] DeprecationWarning: 'GLOBAL' is deprecated, use 'global'

### DIFF
--- a/lib/stores/redisWorkerStore.js
+++ b/lib/stores/redisWorkerStore.js
@@ -15,10 +15,10 @@ function RedisWorkerStore(host, port, prefix, redisOptions) {
   this.commandLog = null;
 
   var redisKey = ['RedisWorkerStoreRedisPool', host + ':' + port];
-  this.redis = _.get(GLOBAL, redisKey);
+  this.redis = _.get(global, redisKey);
   if (!this.redis) {
     this.redis = Redis.createClient(port, host, redisOptions);
-    _.set(GLOBAL, redisKey, this.redis);
+    _.set(global, redisKey, this.redis);
   }
 }
 


### PR DESCRIPTION
Some detail:
https://nodejs.org/api/deprecations.html#deprecations_dep0016_global_root