### PR TITLE
reconfigure for github packages publish

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@machinemetrics:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${NPM_GITHUB_TOKEN}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "private": "true",
-  "name": "worker-state",
+  "name": "@machinemetrics/worker-state",
   "description": "A data checkpointing service for Kinesis or other stream/batch applications",
   "version": "0.1.0",
   "main": "lib",
@@ -11,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/machinemetrics/worker-state"
+    "url": "https://github.com/machinemetrics/worker-state.git"
   },
   "dependencies": {
     "async-q": "^0.2.2",


### PR DESCRIPTION
[refactor] (internal) update `package.json` and add `.npmrc` to enable publishing to github packages.

Follows procedures in https://machinemetrics.atlassian.net/wiki/spaces/AP/pages/184615024/Publishing+private+node+packages. We could use circle here to publish a new version on merge.